### PR TITLE
Support Neomake and ALE

### DIFF
--- a/colors/paramount.vim
+++ b/colors/paramount.vim
@@ -206,6 +206,14 @@ call s:h("SyntasticWarning",        {"bg": s:yellow, "fg": s:black, "gui": "bold
 call s:h("SyntasticErrorSign",      {"fg": s:red})
 call s:h("SyntasticError",          {"bg": s:red, "fg": s:white, "gui": "bold", "cterm": "bold"})
 
+" Neomake
+hi link NeomakeWarningSign	SyntasticWarningSign
+hi link NeomakeErrorSign	SyntasticErrorSign
+
+" ALE
+hi link ALEWarningSign	SyntasticWarningSign
+hi link ALEErrorSign	SyntasticErrorSign
+
 " Signify, git-gutter
 hi link SignifySignAdd              LineNr
 hi link SignifySignDelete           LineNr


### PR DESCRIPTION
Neomake and ALE also add error and warning signs to the gutter, render
them as we would those from Syntastic.

Neomake also uses highlighting groups for message and info signs, which
this change does not support yet.