### PR TITLE
Add Lightline colorscheme

### DIFF
--- a/autoload/lightline/colorscheme/paramount.vim
+++ b/autoload/lightline/colorscheme/paramount.vim
@@ -1,0 +1,61 @@
+" -----------------------------------------------------------------------------
+" File: paramount.vim
+" Description: Paramount colorscheme for Lightline (itchyny/lightline.vim)
+" Author: samflores <me@samflor.es>
+" Source: https://github.com/samflores/vim-colors-paramount
+" Last Modified: 09 Jan 2019
+" -----------------------------------------------------------------------------
+
+function! s:getColor(group)
+  let guiColor = synIDattr(hlID(a:group), "fg", "gui")
+  let termColor = synIDattr(hlID(a:group), "fg", "cterm")
+  return [ guiColor, termColor ]
+endfunction
+
+if exists('g:lightline')
+  let s:bg1    = s:getColor('LightlineBG1')
+  let s:bg2    = s:getColor('LightlineBG2')
+
+  let s:gray   = s:getColor('LightlineGray')
+  let s:yellow = s:getColor('LightlineYellow')
+  let s:cyan   = s:getColor('LightlineCyan')
+  let s:orange = s:getColor('LightlineOrange')
+  let s:green  = s:getColor('LightlineGreen')
+  let s:purple = s:getColor('LightlinePurple')
+  let s:red    = s:getColor('LightlineRed')
+
+  let s:p = {'normal':{}, 'inactive':{}, 'insert':{}, 'replace':{}, 'visual':{}, 'tabline':{}, 'terminal':{}}
+  let s:p.normal.left     = [ [ s:bg1, s:purple, 'bold' ], [ s:purple, s:bg2 ] ]
+  let s:p.normal.right    = [ [ s:bg1, s:purple ],         [ s:purple, s:bg2 ] ]
+  let s:p.normal.middle   = [ [ s:purple, s:bg2 ] ]
+
+  let s:p.normal.error    = [ [ s:bg1, s:red ] ]
+  let s:p.normal.warning  = [ [ s:bg2, s:yellow ] ]
+
+  let s:p.inactive.right  = [ [ s:gray, s:bg2 ], [ s:gray, s:bg2 ] ]
+  let s:p.inactive.left   = [ [ s:gray, s:bg2 ], [ s:gray, s:bg2 ] ]
+  let s:p.inactive.middle = [ [ s:gray, s:bg2 ] ]
+
+  let s:p.insert.left     = [ [ s:bg1, s:green, 'bold' ], [ s:green, s:bg2 ] ]
+  let s:p.insert.right    = [ [ s:bg1, s:green ],         [ s:green, s:bg2 ] ]
+  let s:p.insert.middle   = [ [ s:green, s:bg2 ] ]
+
+  let s:p.terminal.left   = [ [ s:bg1, s:cyan, 'bold' ], [ s:cyan, s:bg2 ] ]
+  let s:p.terminal.right  = [ [ s:bg1, s:cyan ],         [ s:cyan, s:bg2 ] ]
+  let s:p.terminal.middle = [ [ s:cyan, s:bg2 ] ]
+
+  let s:p.replace.left    = [ [ s:bg1, s:orange, 'bold' ], [ s:orange, s:bg2 ] ]
+  let s:p.replace.right   = [ [ s:bg1, s:orange ],         [ s:orange, s:bg2 ] ]
+  let s:p.replace.middle  = [ [ s:orange, s:bg2 ] ]
+
+  let s:p.visual.left     = [ [ s:bg1, s:yellow, 'bold' ], [ s:yellow, s:bg2 ] ]
+  let s:p.visual.right    = [ [ s:bg1, s:yellow ],         [ s:yellow, s:bg2 ] ]
+  let s:p.visual.middle   = [ [ s:yellow, s:bg2 ] ]
+
+  let s:p.tabline.left    = [ [ s:purple, s:bg2 ] ]
+  let s:p.tabline.tabsel  = [ [ s:bg1, s:purple, 'bold' ] ]
+  let s:p.tabline.middle  = [ [ s:bg1, s:bg1 ] ]
+  let s:p.tabline.right   = [ [ s:bg1, s:purple ] ]
+
+  let g:lightline#colorscheme#paramount#palette = lightline#colorscheme#flatten(s:p)
+endif

--- a/colors/paramount.vim
+++ b/colors/paramount.vim
@@ -206,6 +206,18 @@ call s:h("SyntasticWarning",        {"bg": s:yellow, "fg": s:black, "gui": "bold
 call s:h("SyntasticErrorSign",      {"fg": s:red})
 call s:h("SyntasticError",          {"bg": s:red, "fg": s:white, "gui": "bold", "cterm": "bold"})
 
+" Lightline
+call s:h("LightlineBG1",    {"fg": s:bg})
+call s:h("LightlineBG2",    {"fg": s:bg_very_subtle})
+
+call s:h("LightlineGray",   {"fg": s:bg_subtle})
+call s:h("LightlineYellow", {"fg": s:yellow})
+call s:h("LightlineCyan",   {"fg": s:light_cyan})
+call s:h("LightlineOrange", {"fg": s:orange})
+call s:h("LightlineGreen",  {"fg": s:light_green})
+call s:h("LightlinePurple", {"fg": s:purple})
+call s:h("LightlineRed",    {"fg": s:red})
+
 " Neomake
 hi link NeomakeWarningSign	SyntasticWarningSign
 hi link NeomakeErrorSign	SyntasticErrorSign


### PR DESCRIPTION
Add color scheme for the Lightline plugin (https://github.com/itchyny/lightline.vim).

Normal
![normal](https://user-images.githubusercontent.com/17452/50924775-4b3fc680-142f-11e9-81d3-1fd1c246a0a4.png)

Insert
![insert](https://user-images.githubusercontent.com/17452/50924777-4d098a00-142f-11e9-83a4-cdc240f3ff66.png)

Visual
![visual](https://user-images.githubusercontent.com/17452/50924781-50047a80-142f-11e9-981e-80df9fa9773c.png)

Replace
![replace](https://user-images.githubusercontent.com/17452/50924788-54309800-142f-11e9-9d81-dee949d8de92.png)

Inactive
![inactive](https://user-images.githubusercontent.com/17452/50924792-5692f200-142f-11e9-9fec-bbfe20c1c192.png)

Terminal
![terminal](https://user-images.githubusercontent.com/17452/50924821-66aad180-142f-11e9-8041-3e9462b8e9e5.png)

Tabline
![tabline](https://user-images.githubusercontent.com/17452/50924795-5a267900-142f-11e9-823d-3b8f03c1d4d4.png)

